### PR TITLE
Mount secret to tide and correct the mistakes of tide config.

### DIFF
--- a/starter-s3.yaml
+++ b/starter-s3.yaml
@@ -121,15 +121,15 @@ data:
       - orgs:
         - kitex-contrib
         excludedRepos:
-        - monitor-prometheus
-        - registry-nacos
-        - tracer-opentracing
-        - registry-eureka
-        - registry-consul
-        - registry-polaris
-        - registry-etcd
-        - registry-zookeeper
-        - resolver-dns
+        - kitex-contrib/monitor-prometheus
+        - kitex-contrib/registry-nacos
+        - kitex-contrib/tracer-opentracing
+        - kitex-contrib/registry-eureka
+        - kitex-contrib/registry-consul
+        - kitex-contrib/registry-polaris
+        - kitex-contrib/registry-etcd
+        - kitex-contrib/registry-zookeeper
+        - kitex-contrib/resolver-dns
         labels:
         - lgtm
         - approved
@@ -483,6 +483,9 @@ spec:
       - name: s3-credentials
         secret:
           secretName: s3-credentials
+      - name: github-token-robot
+        secret:
+          secretName: github-token-robot
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
# Mount secret to tide and correct the mistakes of tide config.

## Problem description

Some error happens when we apply our new prow with our updated image of tide.

## My Opinion

1. Is it possible that it's the consequence of forgetting to mount our github-token-robot secret token to tide?

2. prow version problem.



